### PR TITLE
Informative "no data notices" and reactive charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2023-09-16
+
+### Added
+- Added placeholder examples for new Vital form
+- Added methods for creating sample vitals for body weight, heart rate
+- Informative notice for no data added to Measurements page
+- Informative notice for no data added to Person page
+- Informative notice for no data added to Vitals page
+- Add measurement route added for Person
+
+### Changed
+- Added documentation notes to stores
+- Add measurement form add action and cancel lead to previous route
+
+### Fixed
+- Vital chart on Person page more reactive with computed data
+
 ## [0.1.1] - 2023-09-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "healthrecord",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Dashboard/Measurements/Add.vue
+++ b/src/components/Dashboard/Measurements/Add.vue
@@ -8,12 +8,12 @@ const router = useRouter();
 
 const addMeasurement = (measurement) => {
   measurementStore.add(measurement);
-  router.push({name: 'Measurements'});
+  router.back();
 }
 </script>
 
 <template>
-  <Dialog :open="true" @close="$router.push({ name: 'Measurements' })" class="relative z-50">
+  <Dialog :open="true" @close="$router.back()" class="relative z-50">
     <div class="fixed inset-0 bg-black/30 backdrop-blur-sm" />
     <div class="fixed flex w-screen h-screen top-10 items-start md:items-center justify-center">
       <DialogPanel class="bg-white w-full max-w-xs rounded-2xl shadow-lg">

--- a/src/components/Dashboard/Measurements/Form.vue
+++ b/src/components/Dashboard/Measurements/Form.vue
@@ -61,7 +61,7 @@ const vital = computed(() => {
     </label>
     <input v-model="date" type="date" id="date" required>
     <div class="grid grid-flow-col justify-end items-center gap-5 mt-4">
-      <RouterLink :to="{ name: 'Measurements' }" class="text-sm text-gray-500 font-light">Cancel</RouterLink>
+      <a @click="$router.back()" class="text-sm text-gray-500 font-light cursor-pointer">Cancel</a>
       <button type="submit" class="btn" :disabled="!isFormComplete">Save</button>
     </div>
   </form>

--- a/src/components/Dashboard/Measurements/Measurements.vue
+++ b/src/components/Dashboard/Measurements/Measurements.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { PlusIcon } from '@heroicons/vue/24/solid';
+import { QuestionMarkCircleIcon, LightBulbIcon } from '@heroicons/vue/24/outline';
 import { measurements, store as measurementStore } from '../../../store/measurements';
 import { vitals } from '../../../store/vitals';
 import { people } from '../../../store/people';
@@ -49,13 +50,23 @@ const getFormattedDate = (date) => {
           <tr class="border-b even:bg-gray-100" v-for="measurement in measurements" :key="measurement.id">
             <td class="text-sm p-3 pl-4 md:pl-6">{{ getVitalName(measurement.vitalId) }}</td>
             <td class="text-sm p-3 text-gray-400 whitespace-nowrap">{{ Number(measurement.value).toLocaleString() + ' ' + getVitalUnit(measurement.vitalId) }}</td>
-            <td class="text-sm p-3 text-gray-400"> <RouterLink class="text-indigo-800 hover:underline " :to="{ name: 'Person', params: { id: measurement.personId }}">{{ getPersonName(measurement.personId) }}</RouterLink></td>
+            <td class="text-sm p-3 text-gray-400"> <RouterLink class="text-indigo-600 hover:underline " :to="{ name: 'Person', params: { id: measurement.personId }}">{{ getPersonName(measurement.personId) }}</RouterLink></td>
             <td class="text-sm p-3 text-gray-400">{{ getFormattedDate(measurement.date) }}</td>
-            <td class="p-3"><RouterLink class="text-indigo-800 hover:underline text-sm font-medium" :to="{ name: 'EditMeasurement', params: { id: measurement.id }}">Edit</RouterLink></td>
-            <td class="p-3 pr-4 md:pr-6"><button class="text-indigo-800 hover:underline text-sm font-medium" @click.prevent="measurementStore.delete(measurement.id)">Delete</button></td>
+            <td class="p-3"><RouterLink class="text-indigo-600 hover:underline text-sm font-medium" :to="{ name: 'EditMeasurement', params: { id: measurement.id }}">Edit</RouterLink></td>
+            <td class="p-3 pr-4 md:pr-6"><button class="text-indigo-600 hover:underline text-sm font-medium" @click.prevent="measurementStore.delete(measurement.id)">Delete</button></td>
           </tr>
         </tbody>
       </table>
+      <div v-else class="mx-6 border border-amber-200 p-4 rounded-lg text-amber-500 bg-amber-100 text-sm">
+        <p class="grid grid-flow-col grid-cols-[min-content_auto] items-center mb-4 pb-4 border-b border-amber-200">
+          <QuestionMarkCircleIcon class="h-6 w-6 mr-3" />
+          A Measurement is a recording of a specific person's Vital.
+        </p>
+        <p class="grid grid-flow-col grid-cols-[min-content_auto] items-center">
+          <LightBulbIcon class="h-6 w-6 mr-3" />
+          <span>You have not recorded any measurements. <RouterLink class="underline" :to="{ name: 'AddMeasurement' }">Add&nbsp;a&nbsp;measurement</RouterLink>.</span>
+        </p>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/Dashboard/People/People.vue
+++ b/src/components/Dashboard/People/People.vue
@@ -28,11 +28,11 @@ import dayjs from 'dayjs';
       </thead>
       <tbody>
         <tr class="border-b even:bg-gray-100" v-for="person in people" :key="person.id">
-          <td class="p-3 pl-4 md:pl-6"><RouterLink :to="{ name: 'Person', params: { id: person.id }}">{{ person.firstName + ' ' + person.lastName }}</RouterLink></td>
+          <td class="p-3 pl-4 md:pl-6"><RouterLink class="text-indigo-600 hover:underline" :to="{ name: 'Person', params: { id: person.id }}">{{ person.firstName + ' ' + person.lastName }}</RouterLink></td>
           <td class="text-sm p-3 text-center text-gray-400">{{ person.sex.charAt(0) }}</td>
           <td class="text-sm p-3 text-center text-gray-400">{{ dayjs().diff(dayjs(person.dob), 'year') }}</td>
-          <td class="p-3"><RouterLink class="text-indigo-800 hover:underline text-sm font-medium" :to="{ name: 'EditPerson', params: { id: person.id }}">Edit</RouterLink></td>
-          <td class="p-3 pr-4 md:pr-6"><button class="text-indigo-800 hover:underline text-sm font-medium" @click.prevent="peopleStore.delete(person.id)">Delete</button></td>
+          <td class="p-3"><RouterLink class="text-indigo-600 hover:underline text-sm font-medium" :to="{ name: 'EditPerson', params: { id: person.id }}">Edit</RouterLink></td>
+          <td class="p-3 pr-4 md:pr-6"><button class="text-indigo-600 hover:underline text-sm font-medium" @click.prevent="peopleStore.delete(person.id)">Delete</button></td>
         </tr>
       </tbody>
     </table>

--- a/src/components/Dashboard/People/Person.vue
+++ b/src/components/Dashboard/People/Person.vue
@@ -1,9 +1,11 @@
 <script setup>
+import { LightBulbIcon } from '@heroicons/vue/24/outline';
+import { PlusIcon } from '@heroicons/vue/24/solid';
 import VitalChart from './VitalChart.vue';
 import { computed } from 'vue';
 import { people } from '../../../store/people';
 import { measurements } from '../../../store/measurements';
-import { vitals } from '../../../store/vitals';
+import { vitals, addBodyWeightVital, addHeartRateVital } from '../../../store/vitals';
 import { useRoute } from 'vue-router';
 import pluralize from 'pluralize';
 
@@ -37,13 +39,25 @@ const vitalMeasurements = (vitalId) => {
         <h2 class="text-xl font-bold">{{ person.firstName + ' ' + person.lastName }}</h2>
         <p class="text-sm text-gray-500">Tracking {{ pluralize('measurement', userMeasurements.length, true) }} across {{ pluralize('vital', trackedVitals.length, true) }}.</p>
       </header>
+      <div class="grid justify-end">
+        <RouterLink class="btn" :to="{ name: 'AddPersonMeasurement' }">
+          <PlusIcon /> Add
+        </RouterLink>
+      </div>
     </div>
-    <div class="grid grid-cols-2 grid-rows-2 gap-3 px-4 md:px-6">
+    <div v-if="trackedVitals.length > 0" class="grid grid-cols-2 grid-rows-2 gap-3 px-4 md:px-6">
       <div v-for="vital in trackedVitals" :key="vital.id" class="group bg-white shadow-sm border p-3 rounded-md cursor-pointer hover:shadow">
         <h3 class="font-semibold group-hover:text-indigo-600 mb-1">{{ vital.name }}</h3>
         <p class="text-gray-500 text-sm">{{ pluralize('measurement', vitalMeasurements(vital.id).length, true) }}</p>
-        <VitalChart class="mt-3" :vital="vital" :measurements="vitalMeasurements(vital.id)"  />
+        <VitalChart class="mt-3" :vital="vital" :measurements="vitalMeasurements(vital.id)" />
       </div>
+    </div>
+    <div v-else class="mx-6 border border-amber-200 p-4 rounded-lg text-amber-500 bg-amber-100 text-sm">
+      <p class="grid grid-flow-col grid-cols-[min-content_auto] items-center">
+        <LightBulbIcon class="h-6 w-6 mr-3" />
+        <span v-if="vitals.length === 0">You are not measuring any vitals. <RouterLink class="underline" :to="{ name: 'AddVital' }">Add&nbsp;a&nbsp;vital</RouterLink> or start with <span class="underline cursor-pointer" @click="addBodyWeightVital()">body weight</span> or <span class="underline cursor-pointer" @click="addHeartRateVital()">heart rate</span>.</span>
+        <span v-else>You have not recorded any measurements. <RouterLink class="underline" :to="{ name: 'AddPersonMeasurement' }">Add&nbsp;a&nbsp;measurement</RouterLink>.</span>
+      </p>
     </div>
   </div>
 </template>

--- a/src/components/Dashboard/People/VitalChart.vue
+++ b/src/components/Dashboard/People/VitalChart.vue
@@ -2,29 +2,39 @@
 import { Line } from 'vue-chartjs';
 import AnnotationPlugin from 'chartjs-plugin-annotation';
 import { Chart as ChartJS, Title, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement } from 'chart.js';
+import { computed } from 'vue';
 
 ChartJS.register(Title, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement, AnnotationPlugin)
 
 const props = defineProps([ 'vital', 'measurements' ]);
 
-const measurements = props.measurements.reverse();
-const measurementValues = measurements.map(measurement => measurement.value);
-const measurementDates  = measurements.map(measurement => measurement.date);
+const measurements = computed(() => {
+  return props.measurements.reverse()
+});
 
-const data = {
-  labels: measurementDates,
-  datasets: [
-    {
-      label: props.vital.name,
-      backgroundColor: '#4F46E5',
-      data: measurementValues,
-      borderColor: '#C7D2FE',
-      pointRadius: 4,
-      pointHitRadius: 10,
-      pointHoverBorderWidth: 3,
-    }
-  ]
-}
+const measurementValues = computed(() => {
+  return measurements.value.map(measurement => measurement.value);
+});
+const measurementDates = computed(() => {
+  return measurements.value.map(measurement => measurement.date);
+})
+
+const data = computed(() => {
+  return {
+    labels: measurementDates.value,
+    datasets: [
+      {
+        label: props.vital.name,
+        backgroundColor: '#4F46E5',
+        data: measurementValues.value,
+        borderColor: '#C7D2FE',
+        pointRadius: 4,
+        pointHitRadius: 10,
+        pointHoverBorderWidth: 3,
+      }
+    ]
+  }
+});
 
 const options = {
   plugins: {

--- a/src/components/Dashboard/Vitals/Form.vue
+++ b/src/components/Dashboard/Vitals/Form.vue
@@ -31,27 +31,27 @@ const vital = computed(() => {
     <label for="name">
       Name
     </label>
-    <input v-model="name" type="text" id="name" autocomplete="off" required>
+    <input v-model="name" type="text" id="name" autocomplete="off" placeholder="ex. Heart rate" required>
     <label for="description">
       Description
     </label>
-    <textarea v-model="description" id="description" />
+    <textarea v-model="description" id="description" placeholder="ex. Heart beats per minute."/>
     <label  for="unit">
       Unit of Measurement
     </label>
-    <input v-model="unit" type="text" id="unit" required>
+    <input v-model="unit" type="text" id="unit" placeholder="ex. bpm" autocapitalize="off" required>
     <div class="grid grid-flow-col gap-4">
       <div>
         <label for="high">High value</label>
         <div class="input-group">
-          <input v-model="high" type="text" id="high">
+          <input v-model="high" type="text" id="high" placeholder="ex. 101">
           <span v-if="unit.length > 0">{{ unit }}</span>
         </div>
       </div>
       <div>
         <label for="low">Low value</label>
         <div class="input-group">
-          <input v-model="low" type="text" id="low">
+          <input v-model="low" type="text" id="low" placeholder="ex. 59">
           <span v-if="unit.length > 0">{{ unit }}</span>
         </div>
       </div>

--- a/src/components/Dashboard/Vitals/Vitals.vue
+++ b/src/components/Dashboard/Vitals/Vitals.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { PlusIcon } from '@heroicons/vue/24/solid';
-import { vitals, store as vitalStore } from '../../../store/vitals';
+import { QuestionMarkCircleIcon, LightBulbIcon } from '@heroicons/vue/24/outline';
+import { vitals, store as vitalStore, addBodyWeightVital, addHeartRateVital } from '../../../store/vitals';
 </script>
 
 <template>
@@ -33,11 +34,21 @@ import { vitals, store as vitalStore } from '../../../store/vitals';
             <td class="text-sm p-3 text-gray-400">{{ vital.unit }}</td>
             <td class="text-sm p-3 text-center text-gray-400">{{ vital.high }}</td>
             <td class="text-sm p-3 text-center text-gray-400">{{ vital.low }}</td>
-            <td class="p-3"><RouterLink class="text-indigo-800 hover:underline text-sm font-medium" :to="{ name: 'EditVital', params: { id: vital.id }}">Edit</RouterLink></td>
-            <td class="p-3 pr-4 md:pr-6"><button class="text-indigo-800 hover:underline text-sm font-medium" @click.prevent="vitalStore.delete(vital.id)">Delete</button></td>
+            <td class="p-3"><RouterLink class="text-indigo-600 hover:underline text-sm font-medium" :to="{ name: 'EditVital', params: { id: vital.id }}">Edit</RouterLink></td>
+            <td class="p-3 pr-4 md:pr-6"><button class="text-indigo-600 hover:underline text-sm font-medium" @click.prevent="vitalStore.delete(vital.id)">Delete</button></td>
           </tr>
         </tbody>
       </table>
+      <div v-else class="mx-6 border border-amber-200 p-4 rounded-lg text-amber-500 bg-amber-100 text-sm">
+        <p class="grid grid-flow-col items-center grid-cols-[min-content_auto] mb-4 pb-4 border-b border-amber-200">
+          <QuestionMarkCircleIcon class="h-6 w-6 mr-4" />
+          A Vital is a metric that can be measured like heart rate, body weight, or a lab result.
+        </p>
+        <p class="grid grid-flow-col grid-cols-[min-content_auto] items-center">
+          <LightBulbIcon class="h-6 w-6 mr-3" />
+          <span>You are not measuring any vitals. <RouterLink class="underline" :to="{ name: 'AddVital' }">Add&nbsp;a&nbsp;vital</RouterLink> or start with <span class="underline cursor-pointer" @click="addBodyWeightVital()">body weight</span> or <span class="underline cursor-pointer" @click="addHeartRateVital()">heart rate</span>.</span>
+        </p>
+      </div>
     </div>
   </div>
 </template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -137,6 +137,14 @@ const routes = [
         }
       },
       {
+        path: '/people/:id/measurement/add',
+        name: 'AddPersonMeasurement',
+        components: {
+          main: Person,
+          modal: AddMeasurement
+        }
+      },
+      {
         path: '/people/:id/edit',
         name: 'EditPerson',
         components: {

--- a/src/store/measurements.js
+++ b/src/store/measurements.js
@@ -2,10 +2,20 @@ import { computed, reactive } from "vue";
 import { record, store as recordStore } from './record';
 import { v4 as uuidv4 } from 'uuid';
 
+/**
+ * All recorded measurements
+ * 
+ * @since 0.1.0
+ */
 export const measurements = computed(() => {
   return record.value.measurements.sort((a, b) => b.date - a.date );
 });
 
+/**
+ * Measurement store
+ * 
+ * @since 0.1.0
+ */
 export const store = reactive({
   add({ value, date, personId, vitalId }) {
     const measurement = {

--- a/src/store/people.js
+++ b/src/store/people.js
@@ -2,10 +2,20 @@ import { computed, reactive } from "vue";
 import { record, store as recordStore } from "./record";
 import { v4 as uuidv4 } from 'uuid';
 
+/**
+ * All tracked people
+ * 
+ * @since 0.1.0
+ */
 export const people = computed(() => {
   return record.value.people
 });
 
+/**
+ * People store
+ * 
+ * @since 0.1.0
+ */
 export const store = reactive({
   add({ firstName, lastName, sex, dob }) {
     const recordCopy = record.value;

--- a/src/store/record.js
+++ b/src/store/record.js
@@ -3,10 +3,20 @@ import { store as peopleStore } from './people';
 
 const recordVersion = 1;
 
+/**
+ * Browser stored health record
+ * 
+ * @since 0.1.0
+ */
 export const record = computed(() => {
   return store.record;
 });
 
+/**
+ * Record store
+ * 
+ * @since 0.1.0
+ */
 export const store  = reactive({
   record: JSON.parse(localStorage.getItem('healthRecord')),
   add({ person }) {

--- a/src/store/vitals.js
+++ b/src/store/vitals.js
@@ -2,10 +2,50 @@ import { computed, reactive } from "vue";
 import { record, store as recordStore } from './record';
 import { v4 as uuidv4 } from 'uuid';
 
+/**
+ * All vitals
+ * 
+ * @since 0.1.0
+ */
 export const vitals = computed(() => {
   return record.value.vitals;
 });
 
+/**
+ * Heart rate sample vital
+ * 
+ * @since 0.1.2
+ */
+export const addHeartRateVital = () => {
+  store.add({
+    name: 'Heart Rate',
+    description: 'Heart beats per minute',
+    unit: 'bpm',
+    low: 59,
+    high: 101
+  });
+}
+
+/**
+ * Body weight sample vital
+ * 
+ * @since 0.1.2
+ */
+export const addBodyWeightVital = () => {
+  store.add({
+    name: 'Weight',
+    description: 'Body weight',
+    unit: 'lbs',
+    low: '',
+    high: ''
+  });
+}
+
+/**
+ * Vital store
+ * 
+ * @since 0.1.0
+ */
 export const store = reactive({
   add({ name, description, unit, low, high }) {
     const vital = {


### PR DESCRIPTION
Closes #1 

- Add measurement route added for Person
- Add measurement form add action and cancel lead to previous route
- Informative notice for no data added to Measurements page
- Informative notice for no data added to Person page
- Informative notice for no data added to Vitals page
- Vital chart on Person page more reactive with computed data
- Added placeholder examples for new Vital form
- Added methods for creating sample vitals for body weight, heart rate
- Added documentation notes to stores