### PR TITLE
User defined WebRTC settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ Project Link: [https://github.com/roymckenzie/healthrecord](https://github.com/r
 [Cloudflare-Pages]: https://img.shields.io/badge/Cloudflare%20Pages-F38020?style=for-the-badge&logo=Cloudflare%20Pages&logoColor=white
 [Cloudflare-Pages-url]: https://pages.cloudflare.com/
 
-[Yjs]: https://img.shields.io/badge/yjs-6beb84?style=for-the-badge
+[Yjs]: https://img.shields.io/badge/Yjs-6beb84?style=for-the-badge
 [Yjs-url]: https://docs.yjs.dev/

--- a/src/components/Dashboard/Dash/Dash.vue
+++ b/src/components/Dashboard/Dash/Dash.vue
@@ -14,7 +14,7 @@ import pluralize from 'pluralize';
         <p class="text-sm text-gray-500">HealthRecord data overview.</p>
       </header>
     </div>
-    <div class="grid md:grid-cols-2 grid-rows-2 gap-3">
+    <div class="grid grid-rows-2 md:grid-cols-2 xl:grid-cols-3 gap-3">
       <div class="group grid grid-cols-[auto_min-content] bg-white p-3 rounded-md cursor-pointer shadow-sm hover:shadow hover:bg-gray-50 transition-all" @click="$router.push({ name: 'People' })">
         <div>
           <h3 class="font-semibold mb-1">People</h3>

--- a/src/components/Dashboard/Layout.vue
+++ b/src/components/Dashboard/Layout.vue
@@ -1,24 +1,14 @@
 <script setup>
-import { SquaresPlusIcon, UsersIcon, Cog8ToothIcon, Bars3Icon, XMarkIcon, HomeIcon, ChartBarIcon, HeartIcon, ArrowRightOnRectangleIcon } from '@heroicons/vue/20/solid';
-import { ref } from 'vue';
-import { clear } from '../../helpers/storage'
-import { useRouter } from 'vue-router';
-import { record } from '../../store/record';
+import { SquaresPlusIcon, UsersIcon, Cog8ToothIcon, HomeIcon, ChartBarIcon, HeartIcon, ArrowRightOnRectangleIcon } from '@heroicons/vue/20/solid';
+import { record, preferences } from '../../store/record';
+import { peers, webrtcConnected } from '../../providers/webrtc';
+import pluralize from 'pluralize';
 
-const router = useRouter();
-
-const menuOpen = ref(false);
 
 const scrollToTop = () => {
   window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
-const logout = async () => {
-  if (! confirm('Have you downloaded your health record?') ) {
-    return router.push({ name: 'Settings' });
-  }
-  clear();
-}
 </script>
 
 <template>
@@ -26,20 +16,25 @@ const logout = async () => {
     <div class="dash-layout grid grid-rows-[min-content_auto] grid-cols-1 p-4 py-1 h-screen md:max-h-screen md:min-h-screen md:gap-6 md:py-4 md:pr-0 md:grid-rows-none md:grid-flow-col md:grid-cols-[200px_auto]">
       <div class="main-nav overflow-scroll md:overflow-visible items-center md:items-start z-20 justify-start md:justify-normal bg-gray-900 text-white p-4 py-2 rounded-3xl order-last fixed grid grid-flow-col self-start bottom-6 right-4 left-4 md:h-full md:sticky md:top-0 md:left-auto md:right-auto md:bottom-6 md:order-none md:rounded-xl md:py-6 gap-2 md:gap-4 md:grid-rows-[min-content_auto_min-content]">
         <h2 class="grid grid-flow-col items-center md:block self-start font-bold text-xl md:mb-3">
-          <RouterLink class="grid grid-flow-col items-center md:justify-start gap-1 p-2 md:p-0" :to="{ name: 'Dashboard' }">
+          <RouterLink
+            class="grid grid-flow-col items-center md:justify-start gap-1 p-2 md:p-0"
+            :to="{ name: 'Dashboard' }"
+            aria-label="Dashboard"
+          >
             <SquaresPlusIcon class="h-6 w-6 md:h-5 md:w-5"/> <span class="hidden md:inline">HealthRecord</span>
           </RouterLink>
         </h2>
         <nav @click="scrollToTop();">
-          <ul class="grid gap-2 md:gap-2 grid-flow-col md:grid-flow-row">
+          <ul class="grid gap-2 md:gap-3 grid-flow-col md:grid-flow-row">
             <li>
               <RouterLink 
                 class="grid grid-flow-col gap-3 p-2 px-3 text-sm justify-start items-center rounded-md text-gray-400 hover:bg-gray-800 hover:text-white" 
                 :to="{ name: 'Dashboard' }"
                 active-class="bg-gray-700 text-white hover:bg-gray-700 active"
                 exact-active-class="bg-gray-700 text-white exact-active"
+                aria-label="Dashboard"
               >
-                <HomeIcon class="h-6 w-6 md:h-4 md:w-4" /> <span class="hidden md:inline">Dashboard</span>
+                <HomeIcon class="h-6 w-6" /> <span class="hidden md:inline">Dashboard</span>
               </RouterLink>
             </li>
             <li>
@@ -48,8 +43,9 @@ const logout = async () => {
                 :to="{ name: 'People' }"
                 active-class="bg-gray-700 text-white hover:bg-gray-700 active"
                 exact-active-class="bg-gray-700 text-white exact-active"
+                aria-label="People"
               >
-                <UsersIcon class="h-6 w-6 md:h-4 md:w-4" /> <span class="hidden md:inline">People</span>
+                <UsersIcon class="h-6 w-6" /> <span class="hidden md:inline">People</span>
               </RouterLink>
             </li>
             <li>
@@ -58,8 +54,9 @@ const logout = async () => {
                 :to="{ name: 'Vitals' }"
                 active-class="bg-gray-700 text-white hover:bg-gray-700 active"
                 exact-active-class="bg-gray-700 text-white exact-active"
+                aria-label="Vitals"
               >
-                <HeartIcon class="h-6 w-6 md:h-4 md:w-4" /> <span class="hidden md:inline">Vitals</span>
+                <HeartIcon class="h-6 w-6" /> <span class="hidden md:inline">Vitals</span>
               </RouterLink>
             </li>
             <li>
@@ -68,26 +65,35 @@ const logout = async () => {
                 :to="{ name: 'Measurements' }"
                 active-class="bg-gray-700 text-white hover:bg-gray-700 active"
                 exact-active-class="bg-gray-700 text-white exact-active"
+                aria-label="Measurements"
               >
-                <ChartBarIcon class="h-6 w-6 md:h-4 md:w-4" /> <span class="hidden md:inline">Measurements</span>
+                <ChartBarIcon class="h-6 w-6" /> <span class="hidden md:inline">Measurements</span>
               </RouterLink>
             </li>
+          </ul>
+        </nav>
+        <nav class="">
+          <ul>
             <li>
               <RouterLink 
                 class="grid grid-flow-col gap-3 p-2 px-3 text-sm justify-start items-center rounded-md text-gray-400 hover:bg-gray-800 hover:text-white" 
                 :to="{ name: 'Settings' }"
                 active-class="bg-gray-700 text-white hover:bg-gray-700 active"
                 exact-active-class="bg-gray-700 text-white exact-active"
+                aria-label="Settings"
               >
-                <Cog8ToothIcon class="h-6 w-6 md:h-4 md:w-4" /> <span class="hidden md:inline">Settings</span>
+                <span>
+                  <span 
+                    v-if="preferences.webRTC.enabled && webrtcConnected"
+                    class="h-2 w-2 inline-block bg-orange-300 rounded-full absolute shadow"
+                    :class="{ '!bg-green-500' : peers > 0 }"
+                    :title="peers > 0 ? pluralize('peer', peers, true) + ' connected' : 'Waiting for peers...'"
+                  ></span>
+                  <Cog8ToothIcon class="h-6 w-6 md:h-5 md:w-5" />
+                </span> <span class="hidden md:inline">Settings</span>
               </RouterLink>
             </li>
           </ul>
-        </nav>
-        <nav class="hidden md:mb-0 md:ml-3 md:block" @click="menuOpen = menuOpen ? false : true">
-          <button class="w-full text-sm text-gray-500 grid grid-flow-col p-2 pl-0 md:p-0 gap-3 items-center justify-start" @click.prevent="logout">
-            <ArrowRightOnRectangleIcon class="h-6 w-6 md:h-4 md:w-4" /> <span class="hidden md:inline">Logout</span>
-          </button>
         </nav>
       </div>
       <div class="grid grid-cols-1 md:overflow-y-scroll md:pr-4 md:pb-4 md:-mb-4">

--- a/src/components/Dashboard/Layout.vue
+++ b/src/components/Dashboard/Layout.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { SquaresPlusIcon, UsersIcon, Cog8ToothIcon, HomeIcon, ChartBarIcon, HeartIcon, ArrowRightOnRectangleIcon } from '@heroicons/vue/20/solid';
-import { record, preferences } from '../../store/record';
+import { record } from '../../store/record';
 import { peers, webrtcConnected } from '../../providers/webrtc';
 import pluralize from 'pluralize';
-
+import { store as preferencesStore } from '../../store/preferences';
 
 const scrollToTop = () => {
   window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -84,7 +84,7 @@ const scrollToTop = () => {
               >
                 <span>
                   <span 
-                    v-if="preferences.webRTC.enabled && webrtcConnected"
+                    v-if="preferencesStore.webRTC.enabled && webrtcConnected"
                     class="h-2 w-2 inline-block bg-orange-300 rounded-full absolute shadow"
                     :class="{ '!bg-green-500' : peers > 0 }"
                     :title="peers > 0 ? pluralize('peer', peers, true) + ' connected' : 'Waiting for peers...'"

--- a/src/components/Dashboard/People/Person.vue
+++ b/src/components/Dashboard/People/Person.vue
@@ -47,7 +47,7 @@ const vitalMeasurements = (vitalId) => {
       </div>
     </div>
     <div>
-      <div v-if="trackedVitals.length > 0" class="grid grid-cols-2 gap-3">
+      <div v-if="trackedVitals.length > 0" class="grid grid-cols-2 xl:grid-cols-3 gap-3">
         <div v-for="vital in trackedVitals" :key="vital.id" class="group bg-white p-3 rounded-md cursor-pointer shadow-sm hover:shadow hover:bg-gray-50 transition-all" @click="$router.push({ name: 'PersonVital', params: { vitalId: vital.id } })">
           <header class="grid grid-cols-[auto_min-content]">
             <h3 class="font-semibold mb-1">{{ vital.name }}</h3>

--- a/src/components/Dashboard/Settings/Settings.vue
+++ b/src/components/Dashboard/Settings/Settings.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { record, store as recordStore } from '../../../store/record';
+import { record, downloadable } from '../../../store/record';
 import { saveAs } from 'file-saver';
 import { clear } from '../../../helpers/storage';
 import { DocumentArrowDownIcon, LockClosedIcon } from '@heroicons/vue/24/outline';
@@ -26,7 +26,7 @@ const downloadHealthRecordFile = (data) => {
 
 const passphraseSubmitted = async (passphrase) => {
   passphraseModalOpen.value = false;
-  const encryptedData = await encrypt(JSON.stringify(recordStore.downloadable()), passphrase);
+  const encryptedData = await encrypt(JSON.stringify(downloadable()), passphrase);
 
   if (! encryptedData) {
     return alert('Could not encrypt data.');
@@ -93,7 +93,7 @@ const appVersion = APP_VERSION;
     <div class="bg-white rounded-xl divide-y overflow-hidden mb-5">
       <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center p-3" :key="1">
         <h4 class="font-semibold text-sm">Unencrypted</h4>
-        <button class="btn text-sm" @click="downloadHealthRecordFile(recordStore.downloadable())">
+        <button class="btn text-sm" @click="downloadHealthRecordFile(downloadable())">
           <DocumentArrowDownIcon />
           Download
         </button>

--- a/src/components/Dashboard/Settings/Settings.vue
+++ b/src/components/Dashboard/Settings/Settings.vue
@@ -1,12 +1,19 @@
 <script setup>
-import { record, store as recordStore } from '../../../store/record';
+import { record, preferences, store as recordStore } from '../../../store/record';
 import { saveAs } from 'file-saver';
+import { clear } from '../../../helpers/storage';
 import { DocumentArrowDownIcon, LockClosedIcon } from '@heroicons/vue/24/outline';
 import { encrypt } from '../../../helpers/encrypto';
 import PassphraseModal from './PassphraseModal.vue';
 import { ref } from 'vue';
+import { Switch } from '@headlessui/vue';
+import { peers, webrtcConnected } from '../../../providers/webrtc';
+import pluralize from 'pluralize';
 
 const passphraseModalOpen = ref(false);
+
+/** @type {import('vue').Ref<string>} */
+const signalServerURL = ref(preferences.value.webRTC.signalerUrl || '');
 
 const downloadHealthRecordFile = (data) => {
   const fileName  = 'healthRecord-' + Date.now() + '.json';
@@ -39,6 +46,21 @@ const logout = async () => {
   clear();
 }
 
+const validateSocketUrl = (urlString) => {
+  try {
+    const url = new URL(urlString);
+    return url.protocol === 'ws:' || url.protocol === 'wss:';
+  } catch (error) {
+    return false;
+  }
+}
+
+const updateWebRTC = () => {
+  if (validateSocketUrl(signalServerURL.value)) {
+    preferences.value.webRTC.signalerUrl = signalServerURL.value;
+  }
+}
+
 const appVersion = APP_VERSION;
 </script>
 
@@ -50,34 +72,114 @@ const appVersion = APP_VERSION;
         <p class="text-sm text-gray-500">Update app settings and download data.</p>
       </header>
     </div>
-    <div class="bg-white rounded-xl divide-y">
-      <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center p-3">
-        <h3 class="font-semibold text-sm">Owner</h3>
+    <h3 class="text-xs pl-3 mb-1 uppercase text-gray-500">
+      Record Details
+    </h3>
+    <div class="bg-white rounded-xl divide-y mb-5">
+      <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center p-3 py-4 md:py-5" :key="0">
+        <h4 class="font-semibold text-sm">Owner</h4>
         <span class="whitespace-nowrap">{{ record.firstName + ' ' + record.lastName }}</span>
       </section>
-      <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center p-3">
-        <h3 class="font-semibold text-sm">Data file</h3>
+      <section class="grid grid-flow-col grid-cols-[auto_auto] items-center p-3 py-5 gap-4" :key="0">
+        <h4 class="font-semibold text-sm">ID</h4>
+        <span class="whitespace-nowrap text-gray-400 font-mono text-sm md:text-base truncate text-right inline-block select-all selection:bg-indigo-600 selection:text-white">{{ record.id }}</span>
+      </section>
+    </div>
+    <h3 class="text-xs pl-3 mb-1 uppercase text-gray-500">
+      Download Data
+    </h3>
+    <p class="ml-3 mb-2 text-xs text-gray-400">Download your data to backup or share.</p>
+    <div class="bg-white rounded-xl divide-y overflow-hidden mb-5">
+      <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center p-3" :key="1">
+        <h4 class="font-semibold text-sm">Unencrypted</h4>
         <button class="btn text-sm" @click="downloadHealthRecordFile(recordStore.downloadable())">
           <DocumentArrowDownIcon />
           Download
         </button>
       </section>
-      <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center p-3">
-        <h3 class="font-semibold text-sm">Encrypted data file</h3>
+      <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center p-3 gap-4" :key="2">
+        <span>
+          <h4 class="font-semibold text-sm">
+            Encrypted
+          </h4>
+          <p class="text-xs text-gray-400">You will be asked for a passphrase to secure the data.</p>
+        </span>
         <button class="btn text-sm" @click="passphraseModalOpen = true">
           <LockClosedIcon />
           Download
         </button>
       </section>
-      <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center border-b p-3">
-        <h3 class="font-semibold text-sm">Version</h3>
-        <span>{{ appVersion }}</span>
+    </div>
+    <h3 class="text-xs pl-3 mb-1 uppercase text-gray-500">
+      Collaboration
+    </h3>
+    <p class="ml-3 mb-2 text-xs text-gray-400">Synchronizes open instances of this HealthRecord.</p>
+    <TransitionGroup
+      name="list"
+      tag="div"
+      class="bg-white rounded-xl divide-y overflow-hidden mb-5"
+    >
+      <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center p-3 bg-white z-10 relative" :key="3">
+        <span>
+          <h4 class="font-semibold text-sm">
+            Allow Syncing
+          </h4>
+        </span>
+        <span>
+          <Switch
+            v-model="recordStore.preferences.webRTC.enabled"
+            :class="preferences.webRTC.enabled ? 'active' : ''"
+            class="switch"
+          >
+            <span />
+          </Switch>
+        </span>
       </section>
-      <section class="grid">
-        <h3 class="font-semibold text-sm text-red-600 cursor-pointer p-3 py-4 text-center" @click="logout">Logout</h3>
+      <section
+        v-if="preferences.webRTC.enabled"
+        class="grid grid-flow-row items-center p-3"
+        :key="4"
+      >
+        <span>
+          <span class="grid grid-flow-col items-start place-content-between">
+            <h4 class="font-semibold text-sm mb-3 md:mb-2">Signal Server</h4>
+            <span
+              v-if="webrtcConnected"
+              class="text-xs text-right rounded-full bg-gray-200 p-1 px-3 -mt-1">
+              {{ peers > 0 ? pluralize('peer', peers, true) + ' connected' : 'Waiting for peers...' }}
+              <span 
+                class="h-2 w-2 ml-1 inline-block bg-orange-300 rounded-full"
+                :class="{ '!bg-green-500' : peers > 0 }"
+                :title="peers > 0 ? pluralize('peer', peers, true) + ' connected' : 'Waiting for peers...'"
+              ></span>
+            </span>
+          </span>
+          <p class="text-xs text-gray-400 mb-3">HealthRecord uses a <a href="https://antmedia.io/webrtc-signaling-servers-everything-you-need-to-know/" target="_blank" class="underline">signal server</a> to find other open instances of this record to synchronize. Synchronization happens peer-to-peer and your data is never transmitted to the signaling server.</p>
+        </span>
+        <span>
+          <input id="signal-server-url" class="w-full font-mono md:text-sm" type="url" placeholder="wss://signal-server.com" v-model="signalServerURL" @blur="updateWebRTC" />
+          <span
+            v-if="signalServerURL.length > 0 && !validateSocketUrl(signalServerURL)"
+            class="text-right block text-xs text-red-600 pt-1"
+          >Please enter a valid WebSocket url</span>
+        </span>
+      </section>
+    </TransitionGroup>
+    <h3 class="text-xs pl-3 mb-1 uppercase text-gray-500">
+      App Info
+    </h3>
+    <div class="bg-white rounded-xl divide-y overflow-hidden relative mb-5">
+      <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center p-3 py-5" :key="5">
+        <h4 class="font-semibold text-sm">Version</h4>
+        <span class="text-gray-400 font-mono">{{ appVersion }}</span>
+      </section>
+    </div>
+    <div class="bg-white hover:bg-gray-50 rounded-xl divide-y overflow-hidden relative mb-5">
+      <section class="grid" :key="6">
+        <h4 class="font-semibold text-sm text-red-600 cursor-pointer p-3 py-5 text-center" @click="logout">Logout</h4>
       </section>
     </div>
     <PassphraseModal v-if="passphraseModalOpen" @close="passphraseModalOpen = false" @passphraseSubmitted="passphraseSubmitted" />
-    <p class="text-center self-end text-xs text-gray-400 mt-6 mb-3">HealthRecord Copyright &copy; {{ new Date().getFullYear() }}</p>
+    <p class="text-center self-end text-xs text-gray-400 mt-6 pb-28">HealthRecord Copyright &copy; {{ new Date().getFullYear() }}</p>
   </div>
 </template>

--- a/src/components/Dashboard/Settings/Settings.vue
+++ b/src/components/Dashboard/Settings/Settings.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { record, preferences, store as recordStore } from '../../../store/record';
+import { record, store as recordStore } from '../../../store/record';
 import { saveAs } from 'file-saver';
 import { clear } from '../../../helpers/storage';
 import { DocumentArrowDownIcon, LockClosedIcon } from '@heroicons/vue/24/outline';
@@ -9,11 +9,12 @@ import { ref } from 'vue';
 import { Switch } from '@headlessui/vue';
 import { peers, webrtcConnected } from '../../../providers/webrtc';
 import pluralize from 'pluralize';
+import { store as preferencesStore } from '../../../store/preferences';
 
 const passphraseModalOpen = ref(false);
 
 /** @type {import('vue').Ref<string>} */
-const signalServerURL = ref(preferences.value.webRTC.signalerUrl || '');
+const signalServerURL = ref(preferencesStore.webRTC.signalerUrl || '');
 
 const downloadHealthRecordFile = (data) => {
   const fileName  = 'healthRecord-' + Date.now() + '.json';
@@ -57,7 +58,7 @@ const validateSocketUrl = (urlString) => {
 
 const updateWebRTC = () => {
   if (validateSocketUrl(signalServerURL.value)) {
-    preferences.value.webRTC.signalerUrl = signalServerURL.value;
+    preferencesStore.webRTC.signalerUrl = signalServerURL.value;
   }
 }
 
@@ -88,7 +89,7 @@ const appVersion = APP_VERSION;
     <h3 class="text-xs pl-3 mb-1 uppercase text-gray-500">
       Download Data
     </h3>
-    <p class="ml-3 mb-2 text-xs text-gray-400">Download your data to backup or share.</p>
+    <p class="ml-3 mb-2 text-xs text-gray-400">Download your data to backup or sharing.</p>
     <div class="bg-white rounded-xl divide-y overflow-hidden mb-5">
       <section class="grid grid-flow-col grid-cols-[auto_min-content] items-center p-3" :key="1">
         <h4 class="font-semibold text-sm">Unencrypted</h4>
@@ -127,8 +128,8 @@ const appVersion = APP_VERSION;
         </span>
         <span>
           <Switch
-            v-model="recordStore.preferences.webRTC.enabled"
-            :class="preferences.webRTC.enabled ? 'active' : ''"
+            v-model="preferencesStore.webRTC.enabled"
+            :class="preferencesStore.webRTC.enabled ? 'active' : ''"
             class="switch"
           >
             <span />
@@ -136,7 +137,7 @@ const appVersion = APP_VERSION;
         </span>
       </section>
       <section
-        v-if="preferences.webRTC.enabled"
+        v-if="preferencesStore.webRTC.enabled"
         class="grid grid-flow-row items-center p-3"
         :key="4"
       >

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -1,111 +1,15 @@
+import '../providers/indexeddb';
+import '../providers/webrtc';
 import { record } from '../store/record';
-import { Doc } from 'yjs';
-import * as Vue from 'vue';
-import { enableVueBindings, syncedStore } from '@syncedstore/core';
-import { connect as webRTCConnect, disconnect as webRTCDisconnect } from '../providers/webrtc';
-import { connect as iDBConnect, disconnect as iDBDisconnect } from '../providers/indexeddb';
-import { watch } from 'vue';
-import { Y } from '@syncedstore/core';
-import { Buffer } from 'buffer';
-import '../store/preferences';
-
-enableVueBindings(Vue);
-
-localStorage.log = 'y-webrtc'
+import { createSyncedStore, doc, load as _load } from '../providers/syncedstore';
 
 const recordVersion = "2";
 
-const doc = new Doc();
+record.value = createSyncedStore();
 
-/** @type {import('@syncedstore/core/types/doc').DocTypeDescription} */
-const shape = {
-  id: 'text',
-  version: 'text',
-  firstName: 'text',
-  lastName: 'text',
-  /** @type {import('../typedefs'.Person[])} */
-  people: [],
-  /** @type {import('../typedefs'.Vital[])} */
-  vitals: [],
-  /** @type {import('../typedefs'.Measurement[])} */
-  measurements: []
-}
-
-const connectProviders = () => {
-  webRTCConnect();
-  iDBConnect();
-}
-
-const disconnectProviders = () => {
-  iDBDisconnect();
-  webRTCDisconnect();
-}
-
-/**
- * Imports HealthRecord data into a SyncedStore, extracts doc, and applies to existing as Doc update
- * 
- * @param {import('../typedefs').HealthRecord} recordData Stringified HealthRecord data
- */
-const importRecord = (recordData) => {
-
-  const newDoc = new Y.Doc();
-
-  const recordSyncedStore = syncedStore(shape, newDoc);
-  recordSyncedStore.version.insert(0, recordVersion);
-  recordSyncedStore.firstName.insert(0, recordData.firstName);
-  recordSyncedStore.lastName.insert(0, recordData.lastName);
-  recordSyncedStore.people.push(...recordData.people);
-  recordSyncedStore.vitals.push(...recordData.vitals);
-  recordSyncedStore.measurements.push(...recordData.measurements);
-
-  migrate(recordData, recordSyncedStore);
-
-  const encoded = Y.encodeStateAsUpdate(newDoc);
-
-  Y.applyUpdate(doc, encoded);
-}
-
-/**
- * Import state from Yjs Doc Uint8Array state
- * 
- * @param {{type: string, state: Uint8Array, prefs: import('../typedefs').PersonPreferences}} recordData 
- */
-const importState = (recordData) => {
-  const state = recordData.state;
-  const update = Buffer.from(state, 'base64');
-  Y.applyUpdate(doc, update);
-}
-
-/**
- * Run migrations for older record versions
- * @param {import("../typedefs").HealthRecord} importedRecord 
- * @param {import('@syncedstore/core/types/doc').MappedTypeDescription<import('../typedefs').HealthRecord>} syncedStore 
- */
-const migrate = (importedRecord, syncedStore) => {
-  if (! importedRecord.version || importedRecord.version <= 1) {
-    syncedStore.id.insert(0, crypto.randomUUID());
-  } else {
-    syncedStore.id.insert(0, importedRecord.id);
-  }
-}
-
-/**
- * Load HealthRecord data from stringified JSON
- * 
- * @param {string} recordData Record JSON stringified
- */
-export const load = (recordData) => {
-  const recordObject = JSON.parse(recordData);
-  if ('state' in recordObject) {
-    importState(recordObject);
-  } else {
-    importRecord(recordObject)
-  }
-  record.value = syncedStore(shape, doc);
-}
+export const load = _load;
 
 export const clear = () => {
-  disconnectProviders();
   doc.destroy();
   record.value = null;
 }
@@ -127,18 +31,8 @@ export const create = (person) => {
   load(JSON.stringify(record));
 }
 
-watch(record, (value) => {
-  if (value) {
-    connectProviders();
-  } else {
-    disconnectProviders();
-  }
-});
-
+// Support pulling in original storage
 if (localStorage.getItem('healthRecord')) {
-  // Support pulling in original storage
   load(localStorage.getItem('healthRecord'));
   localStorage.removeItem('healthRecord');
-} else if (localStorage.getItem('isActive')) {
-  record.value = syncedStore(shape, doc);
 }

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -1,4 +1,4 @@
-import { record, preferences, store as recordStore } from '../store/record';
+import { record } from '../store/record';
 import { Doc } from 'yjs';
 import * as Vue from 'vue';
 import { enableVueBindings, syncedStore } from '@syncedstore/core';
@@ -7,6 +7,7 @@ import { connect as iDBConnect, disconnect as iDBDisconnect } from '../providers
 import { watch } from 'vue';
 import { Y } from '@syncedstore/core';
 import { Buffer } from 'buffer';
+import '../store/preferences';
 
 enableVueBindings(Vue);
 
@@ -31,7 +32,8 @@ const shape = {
 }
 
 const connectProviders = () => {
-  iDBConnect(doc);
+  webRTCConnect();
+  iDBConnect();
 }
 
 const disconnectProviders = () => {
@@ -133,33 +135,10 @@ watch(record, (value) => {
   }
 });
 
-watch([() => preferences.value.webRTC.enabled, () => preferences.value.webRTC.signalerUrl], () => {
-  localStorage.setItem('preferences', JSON.stringify(preferences.value));
-  if (preferences.value.webRTC.enabled) {
-    webRTCConnect(doc);
-  } else {
-    webRTCDisconnect();
-  }
-});
-
 if (localStorage.getItem('healthRecord')) {
   // Support pulling in original storage
   load(localStorage.getItem('healthRecord'));
   localStorage.removeItem('healthRecord');
 } else if (localStorage.getItem('isActive')) {
   record.value = syncedStore(shape, doc);
-}
-
-if (localStorage.getItem('preferences')) {
-  /** @type {import('../typedefs').PersonPreferences} */
-  const prefs = JSON.parse(localStorage.getItem('preferences'));
-  preferences.value = prefs;
-} else {
-  const prefs = {
-    webRTC: {
-      enabled: false,
-      signalerUrl: null
-    }
-  }
-  preferences.value = prefs;
 }

--- a/src/providers/indexeddb.js
+++ b/src/providers/indexeddb.js
@@ -19,9 +19,8 @@ const connect = () => {
 }
 
 const disconnect = () => {
-  if (iDBProvider) {
-    iDBProvider.clearData();
-    iDBProvider.destroy()
-  }
+  if (!iDBProvider) return;
+  iDBProvider.clearData();
+  iDBProvider.destroy()
   iDBProvider = null;
 }

--- a/src/providers/indexeddb.js
+++ b/src/providers/indexeddb.js
@@ -1,21 +1,24 @@
-import { getYjsDoc } from '@syncedstore/core';
 import { IndexeddbPersistence } from 'y-indexeddb';
+import { doc } from './syncedstore';
 import { record } from '../store/record';
+import { watch } from 'vue';
 
 /** @type {IndexeddbPersistence | undefined} */
 let iDBProvider;
 
-/**
- * @param {import('yjs').Doc} doc Underlying yDoc for active HealthRecord
- * 
- * @returns {IndexeddbPersistence}
- */
-export const connect = () => {
-  const doc = getYjsDoc(record.value);
+watch(record, () => {
+  if (record.value) {
+    connect();
+  } else {
+    disconnect();
+  }
+});
+
+const connect = () => {
   iDBProvider = new IndexeddbPersistence('health-record', doc);
 }
 
-export const disconnect = () => {
+const disconnect = () => {
   if (iDBProvider) {
     iDBProvider.clearData();
     iDBProvider.destroy()

--- a/src/providers/indexeddb.js
+++ b/src/providers/indexeddb.js
@@ -1,4 +1,6 @@
+import { getYjsDoc } from '@syncedstore/core';
 import { IndexeddbPersistence } from 'y-indexeddb';
+import { record } from '../store/record';
 
 /** @type {IndexeddbPersistence | undefined} */
 let iDBProvider;
@@ -8,9 +10,9 @@ let iDBProvider;
  * 
  * @returns {IndexeddbPersistence}
  */
-export const connect = (doc) => {
+export const connect = () => {
+  const doc = getYjsDoc(record.value);
   iDBProvider = new IndexeddbPersistence('health-record', doc);
-  return iDBProvider;
 }
 
 export const disconnect = () => {

--- a/src/providers/syncedstore.js
+++ b/src/providers/syncedstore.js
@@ -1,0 +1,81 @@
+import { Doc } from 'yjs';
+import syncedStore from '@syncedstore/core';
+import { enableVueBindings } from '@syncedstore/core';
+import * as Vue from 'vue';
+import { Buffer } from 'buffer';
+import { applyUpdate } from 'yjs';
+import { record } from '../store/record';
+
+enableVueBindings(Vue);
+
+export const doc = new Doc();
+
+// /** @type {import('@syncedstore/core/types/doc').DocTypeDescription} */
+const shape = {
+  id: 'text',
+  version: 'text',
+  firstName: 'text',
+  lastName: 'text',
+  /** @type {import('../typedefs'.Person[])} */
+  people: [],
+  /** @type {import('../typedefs'.Vital[])} */
+  vitals: [],
+  /** @type {import('../typedefs'.Measurement[])} */
+  measurements: []
+}
+
+export const createSyncedStore = () => {
+  return syncedStore(shape, doc);
+}
+
+/**
+ * @param {string} recordData Record JSON stringified
+ */
+export const load = (recordData) => {
+  const recordObject = JSON.parse(recordData);
+  if ('state' in recordObject) {
+    importState(recordObject);
+  } else {
+    importRecord(recordObject)
+  }
+  record.value = syncedStore(shape, doc);
+}
+
+/**
+ * Imports HealthRecord data into a SyncedStore, extracts doc, and applies to existing as Doc update
+ * @param {import('../typedefs').HealthRecord} recordData Stringified HealthRecord data
+ */
+const importRecord = (recordData) => {
+
+  record.value.version.insert(0, recordVersion);
+  record.value.firstName.insert(0, recordData.firstName);
+  record.value.lastName.insert(0, recordData.lastName);
+  record.value.people.push(...recordData.people);
+  record.value.vitals.push(...recordData.vitals);
+  record.value.measurements.push(...recordData.measurements);
+
+  migrate(recordData, record.value);
+}
+
+/**
+ * Import state from Yjs Doc Uint8Array state
+ * @param {{type: string, state: Uint8Array, prefs: import('../typedefs').PersonPreferences}} recordData 
+ */
+const importState = (recordData) => {
+  const state = recordData.state;
+  const update = Buffer.from(state, 'base64');
+  applyUpdate(doc, update);
+}
+
+/**
+ * Run migrations for older record versions
+ * @param {import("../typedefs").HealthRecord} importedRecord 
+ * @param {import('@syncedstore/core/types/doc').MappedTypeDescription<import('../typedefs').HealthRecord>} syncedStore 
+ */
+const migrate = (importedRecord, syncedStore) => {
+  if (! importedRecord.version || importedRecord.version <= 1) {
+    syncedStore.id.insert(0, crypto.randomUUID());
+  } else {
+    syncedStore.id.insert(0, importedRecord.id);
+  }
+}

--- a/src/providers/webrtc.js
+++ b/src/providers/webrtc.js
@@ -1,33 +1,46 @@
 import { WebrtcProvider } from 'y-webrtc';
+import { preferences, record } from '../store/record';
+import { computed, ref } from 'vue';
 
 /** @type {WebrtcProvider | undefined} */
 let webRTCProvider;
 
 /**
- * @param {string} recordId Active HealthRecord ID
  * @param {import('yjs').Doc} doc Underlying yDoc for active HealthRecord
- * 
- * @returns {WebrtcProvider}
  */
-export const connect = (recordId, doc) => {
+export const connect = (doc) => {
   const signaling = [];
 
-  if (import.meta.env.DEV) {
+  // if (preferences.value.webRTC.enabled && preferences.value.webRTC.signalerUrl) {
+  //   signaling.push(preferences.value.webRTC.signalerUrl);
+  // } else if (import.meta.env.DEV) {
     // See {@link https://github.com/roymckenzie/y-webrtc-signaler ywebrtc-signaler} for sample signaling server implementation
     signaling.push('ws://localhost:8787');
-  }
+  // }
 
-  webRTCProvider = new WebrtcProvider(recordId, doc, {
+  webRTCProvider = new WebrtcProvider(record.value.id, doc, {
     signaling,
   });
 
-  return webRTCProvider;
+  webRTCProvider.on('peers', ({ webrtcPeers }) => {
+    console.log('peeeeeers!');
+    peers.value = webrtcPeers.length
+  });
 }
 
 export const disconnect = () => {
+  console.log('disconnecting webrtc');
   if (webRTCProvider) {
+    webRTCProvider.off('peers');
     webRTCProvider.disconnect();
     webRTCProvider.destroy();
   }
   webRTCProvider = null;
+  peers.value = 0;
 }
+
+export const webrtcConnected = computed(() => {
+  return webRTCProvider !== null;
+})
+
+export const peers = ref(0);

--- a/src/providers/webrtc.js
+++ b/src/providers/webrtc.js
@@ -14,9 +14,9 @@ export const webrtcConnected = computed(() => {
 });
 
 watch(
-  () => [preferencesStore.webRTC.enabled],
-  (enabled) => {
-    if (enabled) {
+  () => preferencesStore.webRTC.enabled,
+  () => {
+    if (preferencesStore.webRTC.enabled) {
       connect();
     } else {
       disconnect();
@@ -34,9 +34,8 @@ watch(record, () => {
 
 
 const connect = () => {  
-  if (!preferencesStore.webRTC.enabled || (webRTCProvider && webRTCProvider.connected)) {
-    return;
-  }
+  if (!preferencesStore.webRTC.enabled || (webRTCProvider && webRTCProvider.connected)) return;
+
   const signaling = [];
 
   if (preferencesStore.webRTC.signalerUrl) {
@@ -46,7 +45,7 @@ const connect = () => {
     signaling.push('ws://localhost:8787');
   }
 
-  const recordId = doc.getText('id');
+  const recordId = doc.getText('id').toString();
 
   webRTCProvider = new WebrtcProvider(recordId, doc, {
     signaling
@@ -58,12 +57,9 @@ const connect = () => {
 }
 
 const disconnect = () => {
-  if (webRTCProvider) {
-    webRTCProvider.destroy();
-    setTimeout(() => {
-      webRTCProvider.disconnect(); peers.value = 0;
-      webRTCProvider = null;
-      peers.value = 0;
-    }, 200);
-  }
+  if (!webRTCProvider) return;
+  webRTCProvider.disconnect();
+  webRTCProvider.destroy();
+  webRTCProvider = null;
+  peers.value = 0
 }

--- a/src/store/preferences.js
+++ b/src/store/preferences.js
@@ -7,17 +7,19 @@ export const store = reactive({
   }
 });
 
-watch(store, (value) => {
-  if (value) {
-    localStorage.setItem('preferences', JSON.stringify(value));
+if (localStorage.getItem('preferences')) {
+  
+  /** @type {import('../typedefs').PersonPreferences} */
+  const prefs = JSON.parse(localStorage.getItem('preferences'));
+
+  store.webRTC.enabled = prefs.webRTC.enabled;
+  store.webRTC.signalerUrl = prefs.webRTC.signalerUrl;
+}
+
+watch(store, () => {
+  if (store) {
+    localStorage.setItem('preferences', JSON.stringify(store));
   } else {
     localStorage.removeItem('preferences');
   }
 });
-
-if (localStorage.getItem('preferences')) {
-  /** @type {import('../typedefs').PersonPreferences} */
-  const prefs = JSON.parse(localStorage.getItem('preferences'));
-  store.webRTC.enabled = prefs.webRTC.enabled;
-  store.webRTC.signalerUrl = prefs.webRTC.signalerUrl;
-}

--- a/src/store/preferences.js
+++ b/src/store/preferences.js
@@ -1,0 +1,23 @@
+import { reactive, watch } from "vue";
+
+export const store = reactive({
+  webRTC: {
+    enabled: false,
+    signalerUrl: null
+  }
+});
+
+watch(store, (value) => {
+  if (value) {
+    localStorage.setItem('preferences', JSON.stringify(value));
+  } else {
+    localStorage.removeItem('preferences');
+  }
+});
+
+if (localStorage.getItem('preferences')) {
+  /** @type {import('../typedefs').PersonPreferences} */
+  const prefs = JSON.parse(localStorage.getItem('preferences'));
+  store.webRTC.enabled = prefs.webRTC.enabled;
+  store.webRTC.signalerUrl = prefs.webRTC.signalerUrl;
+}

--- a/src/store/record.js
+++ b/src/store/record.js
@@ -4,12 +4,6 @@ import { Buffer } from 'buffer';
 
 /** @type {import('vue').ShallowRef<import('@syncedstore/core/types/doc').MappedTypeDescription<import('../typedefs').HealthRecord>>} */
 export const record = shallowRef();
-export const preferences = ref({
-  webRTC: {
-    enabled: false,
-    signalerUrl: null
-  }
-});
 
 /**
  * Record store
@@ -19,8 +13,6 @@ export const preferences = ref({
 export const store  = reactive({
 
   record,
-
-  preferences,
 
   downloadable() {
     const doc = getYjsDoc(record.value);

--- a/src/store/record.js
+++ b/src/store/record.js
@@ -1,9 +1,15 @@
 import { Y, getYjsDoc } from '@syncedstore/core';
-import { reactive, watch, shallowRef } from 'vue';
+import { reactive, watch, shallowRef, ref } from 'vue';
 import { Buffer } from 'buffer';
 
 /** @type {import('vue').ShallowRef<import('@syncedstore/core/types/doc').MappedTypeDescription<import('../typedefs').HealthRecord>>} */
 export const record = shallowRef();
+export const preferences = ref({
+  webRTC: {
+    enabled: false,
+    signalerUrl: null
+  }
+});
 
 /**
  * Record store
@@ -13,6 +19,8 @@ export const record = shallowRef();
 export const store  = reactive({
 
   record,
+
+  preferences,
 
   downloadable() {
     const doc = getYjsDoc(record.value);

--- a/src/store/record.js
+++ b/src/store/record.js
@@ -1,30 +1,21 @@
-import { Y, getYjsDoc } from '@syncedstore/core';
-import { reactive, watch, shallowRef, ref } from 'vue';
+import { getYjsDoc } from '@syncedstore/core';
+import { encodeStateAsUpdate } from 'yjs';
+import { watch, shallowRef } from 'vue';
 import { Buffer } from 'buffer';
 
 /** @type {import('vue').ShallowRef<import('@syncedstore/core/types/doc').MappedTypeDescription<import('../typedefs').HealthRecord>>} */
 export const record = shallowRef();
 
-/**
- * Record store
- * 
- * @since 0.1.0
- */
-export const store  = reactive({
-
-  record,
-
-  downloadable() {
-    const doc = getYjsDoc(record.value);
-    const encodedState = Y.encodeStateAsUpdate(doc);
-    const state = Buffer.from(encodedState).toString('base64');
-    const exportable = {
-      state,
-      type: 'healthRecord'
-    }
-    return exportable;
+export const downloadable = () => {
+  const doc = getYjsDoc(record.value);
+  const encodedState = encodeStateAsUpdate(doc);
+  const state = Buffer.from(encodedState).toString('base64');
+  const exportable = {
+    state,
+    type: 'healthRecord'
   }
-});
+  return exportable;
+}
 
 watch(record, (value) => {
   if (value) {

--- a/src/style.css
+++ b/src/style.css
@@ -15,10 +15,10 @@
 }
 
 .btn {
-  @apply p-2 px-4 rounded bg-indigo-500 text-white grid grid-flow-col gap-2;
+  @apply p-2 px-4 rounded bg-indigo-600 text-white grid grid-flow-col gap-2;
 
   &:hover {
-    @apply bg-indigo-600;
+    @apply bg-indigo-700;
   }
 
   &:disabled {
@@ -27,6 +27,30 @@
 
   svg {
     @apply w-4 h-4 inline-block self-center stroke-white;
+  }
+}
+
+.switch {
+  @apply bg-gray-300 inline-flex h-9 w-16 items-center rounded-full;
+
+  &:hover {
+    @apply bg-gray-400;
+  }
+
+  span {
+    @apply translate-x-1 inline-block h-7 w-7 transform rounded-full bg-white transition;
+  }
+
+  &.active {
+    @apply bg-indigo-600;
+
+    &:hover {
+      @apply bg-indigo-700;
+    }
+
+    span {
+      @apply translate-x-8;
+    }
   }
 }
 
@@ -58,6 +82,29 @@
   }
 }
 
+input[type=text],
+input[type=email],
+input[type=date],
+input[type=password],
+input[type=url],
+textarea,
+select {
+  @apply border-gray-200 rounded py-2 px-3 text-gray-700;
+
+  &:focus {
+    @apply outline-none border-indigo-500 ring-indigo-200 ring-4;
+  }
+
+  &:invalid::-webkit-datetime-edit {
+    @apply text-gray-300
+  }
+
+  &::placeholder {
+    @apply text-gray-300 font-light text-sm
+  }
+}
+
+
 form {
 
   label {
@@ -68,21 +115,10 @@ form {
   input[type=email],
   input[type=date],
   input[type=password],
+  input[type=url],
   textarea,
   select {
-    @apply shadow-sm border-gray-200 rounded w-full py-2 px-3 text-gray-700 mb-3;
-
-    &:focus {
-      @apply outline-none border-indigo-500 ring-indigo-200 ring-4;
-    }
-
-    &:invalid::-webkit-datetime-edit {
-      @apply text-gray-300
-    }
-
-    &::placeholder {
-      @apply text-gray-300 font-light text-sm
-    }
+    @apply shadow-sm mb-3 w-full;
   }
 
   input[type=radio] {
@@ -125,4 +161,26 @@ form {
       @apply grid bg-gray-50 border-l p-1 px-2 text-gray-400 text-sm h-full content-center;
     }
   }
+}
+
+.list-move, /* apply transition to moving elements */
+.list-enter-active,
+.list-leave-active {
+  transition: transform 150ms linear, opacity 100ms;
+  width: 100%;
+}
+
+.list-enter-from,
+.list-leave-to {
+  transform: translateY(-100px);
+  width: 100%;
+  opacity: 0;
+  /* position: absolute; */
+}
+
+/* ensure leaving items are taken out of layout flow so that moving
+   animations can be calculated correctly. */
+.list-leave-active {
+  position: absolute;
+  width: 100%;
 }

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -10,6 +10,17 @@
  */
 
 /**
+ * @typedef {object} PersonPreferences
+ * @property {WebRTCPreference} webRTC
+ */
+
+/**
+ * @typedef {object} WebRTCPreference
+ * @property {boolean} enabled
+ * @property {string | undefined} signalerUrl
+ */
+
+/**
  * @typedef {object} Person
  * @property {string} id
  * @property {string} firstName


### PR DESCRIPTION
This closes #13 with a newly updated Settings screen allowing users to enable or disable peer-to-peer syncing and to input their own signal server address.

This PR also 
- Sets up a new preferences store
- Refactored providers (IndexedDb / WebRTC) modules
- Includes UI changes to navigation in mobile and desktop